### PR TITLE
Add small-things mini cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,6 +91,20 @@ h2.sec::after{content:" ////";color:var(--accent)}
 .card .open::after{content:" +"}
 .card:hover .open{color:var(--ink)}
 
+/* mini cards — small things, no modal */
+.minis{margin-top:48px}
+.minis .grid{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+@media(max-width:560px){.minis .grid{grid-template-columns:1fr}}
+.mini{
+  display:block;border:1.5px solid var(--ink);background:#fff;padding:12px 14px;
+  box-shadow:3px 3px 0 var(--ink);text-decoration:none;font-size:13px;
+  transition:transform .12s ease, box-shadow .12s ease;
+}
+.mini:hover{transform:translate(-2px,-2px);box-shadow:5px 5px 0 var(--accent),5px 5px 0 1.5px var(--ink)}
+.mini h3{font-size:14px;font-weight:800;margin-bottom:4px}
+.mini h3::after{content:" ↗";color:var(--accent);font-weight:400}
+.mini p{font-size:12.5px;color:#333}
+
 .past{margin-top:48px}
 .past ul{list-style:none}
 .past li{border-top:1.5px dashed var(--ink);padding:10px 0;font-size:14px;display:flex;gap:12px;flex-wrap:wrap}
@@ -274,6 +288,21 @@ dialog .close:hover{background:var(--ink)}
           <span class="open">details</span>
         </div>
       </article>
+
+      <div class="minis">
+        <h2 class="sec">Small things</h2>
+        <div class="grid">
+          <a class="mini" href="https://github.com/pjoachims/claude-island">
+            <h3>🏝️ claude-island</h3>
+            <p>Dynamic-island-style notch app for macOS — hover the notch, get a
+            terminal managing all your Claude Code sessions.</p>
+          </a>
+          <a class="mini" href="https://github.com/pjoachims/streamlit-kpi-card">
+            <h3>📈 streamlit-kpi-card</h3>
+            <p>KPI cards for Streamlit with a mini plot below.</p>
+          </a>
+        </div>
+      </div>
 
       <div class="past">
         <h2 class="sec">Earlier</h2>

--- a/index.html
+++ b/index.html
@@ -297,6 +297,11 @@ dialog .close:hover{background:var(--ink)}
             <p>Dynamic-island-style notch app for macOS — hover the notch, get a
             terminal managing all your Claude Code sessions.</p>
           </a>
+          <a class="mini" href="https://github.com/pjoachims/orbeat">
+            <h3>🫀 orbeat</h3>
+            <p>macOS menu-bar heart-rate monitor with BLE rebroadcast + iOS
+            widget companion.</p>
+          </a>
           <a class="mini" href="https://github.com/pjoachims/streamlit-kpi-card">
             <h3>📈 streamlit-kpi-card</h3>
             <p>KPI cards for Streamlit with a mini plot below.</p>


### PR DESCRIPTION
Adds a "Small things" section below Now building: compact link cards for minor projects. Seeded with claude-island and streamlit-kpi-card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)